### PR TITLE
Added handling of the USING clause in CREATE INDEX for dummy-vector-backend

### DIFF
--- a/cql3/statements/index_prop_defs.cc
+++ b/cql3/statements/index_prop_defs.cc
@@ -22,10 +22,7 @@ void cql3::statements::index_prop_defs::validate() {
     if (is_custom && !custom_class) {
         throw exceptions::invalid_request_exception("CUSTOM index requires specifying the index class");
     }
-
-    if (!is_custom && custom_class) {
-        throw exceptions::invalid_request_exception("Cannot specify index class for a non-CUSTOM index");
-    }
+    
     if (!is_custom && !_properties.empty()) {
         throw exceptions::invalid_request_exception("Cannot specify options for a non-CUSTOM index");
     }
@@ -36,15 +33,6 @@ void cql3::statements::index_prop_defs::validate() {
                         db::index::secondary_index::custom_index_option_name));
     }
 
-    // Currently, Scylla does not support *any* class of custom index
-    // implementation. If in the future we do (e.g., SASI, or something
-    // new), we'll need to check for valid values here.
-    if (is_custom && custom_class) {
-        throw exceptions::invalid_request_exception(
-                format("Unsupported CUSTOM INDEX class {}. Note that currently, Scylla does not support SASI or any other CUSTOM INDEX class.",
-                        *custom_class));
-
-    }
 }
 
 index_options_map

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -10,11 +10,14 @@
 
 #pragma once
 
+#include "gms/feature_service.hh"
 #include "schema/schema.hh"
 
 #include "data_dictionary/data_dictionary.hh"
 #include "cql3/statements/index_target.hh"
 
+#include <set>
+#include <string_view>
 #include <vector>
 
 namespace cql3::expr {
@@ -99,6 +102,8 @@ public:
     bool is_index(view_ptr) const;
     bool is_index(const schema& s) const;
     bool is_global_index(const schema& s) const;
+    std::optional<sstring> custom_index_class(const schema& s) const;
+    std::set<std::string_view> supported_custom_classes(const gms::feature_service& fs) const;
 private:
     void add_index(const index_metadata& im);
 };

--- a/replica/schema_describe_helper.hh
+++ b/replica/schema_describe_helper.hh
@@ -11,6 +11,8 @@
 #include "data_dictionary/data_dictionary.hh"
 #include "index/secondary_index_manager.hh"
 #include "schema/schema.hh"
+#include "seastar/core/sstring.hh"
+#include <optional>
 
 namespace replica {
 
@@ -25,6 +27,10 @@ public:
 
     virtual bool is_index(const table_id& base_id, const schema& view_s) const override {
         return  _db.find_column_family(base_id).get_index_manager().is_index(view_s);
+    }
+
+    virtual std::optional<sstring> custom_index_class(const table_id& base_id, const schema& view_s) const override {
+        return  _db.find_column_family(base_id).get_index_manager().custom_index_class(view_s);
     }
 
     virtual schema_ptr find_schema(const table_id& id) const override {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -927,11 +927,21 @@ sstring schema::get_create_statement(const schema_describe_helper& helper, bool 
     if (is_view()) {
         if (helper.is_index(view_info()->base_id(), *this)) {
             auto is_local = !helper.is_global_index(view_info()->base_id(), *this);
+            auto custom_index_class = helper.custom_index_class(view_info()->base_id(), *this);
+
+            if (custom_index_class) {
+                os << "CUSTOM ";
+            }
 
             os << "INDEX " << cql3::util::maybe_quote(secondary_index::index_name_from_table_name(cf_name())) << " ON "
                     << cql3::util::maybe_quote(ks_name()) << "." << cql3::util::maybe_quote(view_info()->base_name());
 
             describe_index_columns(os, is_local, *this, helper.find_schema(view_info()->base_id()));
+            
+            if (custom_index_class) {
+                os << " USING \'" << *custom_index_class << "\'";
+            }
+
             os << ";\n";
 
             return std::move(os).str();

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -541,6 +541,7 @@ class schema_describe_helper {
 public:
     virtual bool is_global_index(const table_id& base_id, const schema& view_s) const = 0;
     virtual bool is_index(const table_id& base_id, const schema& view_s) const = 0;
+    virtual std::optional<sstring> custom_index_class(const table_id& base_id, const schema& view_s) const = 0;
     virtual schema_ptr find_schema(const table_id& id) const = 0;
     virtual ~schema_describe_helper() = default;
 };

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -691,7 +691,7 @@ SEASTAR_TEST_CASE(test_secondary_index_collections) {
 // combination of parameters related to custom indexes are rejected as well.
 SEASTAR_TEST_CASE(test_secondary_index_create_custom_index) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
-        e.execute_cql("create table cf (p int primary key, a int)").get();
+        e.execute_cql("create table cf (p int primary key, a int, b int)").get();
         // Creating an index on column a works, obviously.
         e.execute_cql("create index on cf (a)").get();
         // The following is legal syntax on Cassandra, to create a SASI index.
@@ -708,11 +708,13 @@ SEASTAR_TEST_CASE(test_secondary_index_create_custom_index) {
         // "exceptions::invalid_request_exception: CUSTOM index requires
         // specifying the index class"
         assert_that_failed(e.execute_cql("create custom index on cf (a)"));
-        // It's also a syntax error to try to specify a "USING" without
-        // specifying CUSTOM. We expect the exception:
-        // "exceptions::invalid_request_exception: Cannot specify index class
-        // for a non-CUSTOM index"
-        assert_that_failed(e.execute_cql("create index on cf (a) using 'org.apache.cassandra.index.sasi.SASIIndex'"));
+        // This is the default syntax for specifying a custom index and we 
+        // 'support' "dummy-vector-backend". This should work.
+        e.execute_cql("create custom index on cf (a) using 'dummy-vector-backend'").get();
+        // It's not a syntax error to try to specify a "USING" without
+        // specifying CUSTOM. This should work.
+        e.execute_cql("create index on cf (b) using 'dummy-vector-backend'").get();
+        
     });
 }
 


### PR DESCRIPTION
**This pull request is an implementation of index metadata management**

The patch contains:

* implementation of function returning custom index class name 
* validation used supported custom classes set
* adjustment DESCRIBE to provide information about custom class when applicable
* tests

Implementation of CREATE, DROP and DESCRIBE commands to create indexes of custom type. The syntax is compatible with Cassandra.
Implementation work on metadata, not on the data tier.
After support for the vector datatype is implemented, the CREATE statement should validate whether the index was created on a column of the vector type.

Closes #1 

