### PR TITLE
vector_store: implement vector_store service

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -566,6 +566,7 @@ scylla_tests = set([
     'test/boost/symmetric_key_test',
     'test/boost/types_test',
     'test/boost/utf8_test',
+    'test/boost/vector_store_test',
     'test/boost/vint_serialization_test',
     'test/boost/virtual_table_mutation_source_test',
     'test/boost/wasm_alloc_test',
@@ -1213,6 +1214,7 @@ scylla_core = (['message/messaging_service.cc',
                 'node_ops/task_manager_module.cc',
                 'reader_concurrency_semaphore_group.cc',
                 'utils/disk_space_monitor.cc',
+                'service/vector_store.cc',
                 ] + [Antlr3Grammar('cql3/Cql.g')] \
                   + scylla_raft_core
                )

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -27,6 +27,7 @@
 #include "cql3/untyped_result_set.hh"
 #include "db/config.hh"
 #include "data_dictionary/data_dictionary.hh"
+#include "service/vector_store.hh"
 #include "utils/hashers.hh"
 #include "utils/error_injection.hh"
 #include "service/migration_manager.hh"
@@ -68,11 +69,12 @@ static service::query_state query_state_for_internal_call() {
     return {service::client_state::for_internal_calls(), empty_service_permit()};
 }
 
-query_processor::query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, query_processor::memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, lang::manager& langm)
+query_processor::query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, service::vector_store& vs, query_processor::memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, lang::manager& langm)
         : _migration_subscriber{std::make_unique<migration_subscriber>(this)}
         , _proxy(proxy)
         , _db(db)
         , _mnotifier(mn)
+        , _vector_store(vs)
         , _mcfg(mcfg)
         , _cql_config(cql_cfg)
         , _prepared_cache(prep_cache_log, _mcfg.prepared_statment_cache_size)

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -28,6 +28,7 @@
 #include "transport/messages/result_message.hh"
 #include "service/client_state.hh"
 #include "service/broadcast_tables/experimental/query_result.hh"
+#include "service/vector_store.hh"
 #include "utils/assert.hh"
 #include "utils/observable.hh"
 #include "service/raft/raft_group0_client.hh"
@@ -107,6 +108,7 @@ private:
     service::storage_proxy& _proxy;
     data_dictionary::database _db;
     service::migration_notifier& _mnotifier;
+    service::vector_store& _vector_store;
     memory_config _mcfg;
     const cql_config& _cql_config;
 
@@ -146,7 +148,7 @@ public:
     static std::unique_ptr<statements::raw::parsed_statement> parse_statement(const std::string_view& query, dialect d);
     static std::vector<std::unique_ptr<statements::raw::parsed_statement>> parse_statements(std::string_view queries, dialect d);
 
-    query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, lang::manager& langm);
+    query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, service::vector_store& vs, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, lang::manager& langm);
 
     ~query_processor();
 
@@ -175,6 +177,14 @@ public:
     }
 
     lang::manager& lang() { return _lang_manager; }
+
+    const service::vector_store& vector_store() const noexcept {
+        return _vector_store;
+    }
+
+    service::vector_store& vector_store() noexcept {
+        return _vector_store;
+    }
 
     db::auth_version_t auth_version;
 

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -33,7 +33,8 @@ target_sources(service
     task_manager_module.cc
     topology_coordinator.cc
     topology_mutation.cc
-    topology_state_machine.cc)
+    topology_state_machine.cc
+    vector_store.cc)
 target_include_directories(service
   PUBLIC
     ${CMAKE_SOURCE_DIR})

--- a/service/vector_store.cc
+++ b/service/vector_store.cc
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "vector_store.hh"
+#include "dht/i_partitioner.hh"
+#include "keys.hh"
+#include "utils/rjson.hh"
+#include "schema/schema.hh"
+#include <charconv>
+#include <cstdint>
+#include <cstdlib>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/http/client.hh>
+#include <seastar/http/request.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/util/short_streams.hh>
+#include <stdexcept>
+
+using namespace seastar;
+
+logging::logger vslogger("vector_store");
+
+namespace {
+
+bytes get_key_column_value(const rjson::value& item, std::size_t idx, const column_definition& column) {
+    auto const& column_name = column.name_as_text();
+    auto const* keys_obj = rjson::find(item, column_name);
+    auto const& keys_arr = keys_obj->GetArray();
+    auto const& key = keys_arr[idx];
+    return column.type->from_string(rjson::print(key));
+}
+
+partition_key pk_from_json(rjson::value const& item, std::size_t idx, schema_ptr const& schema) {
+    std::vector<bytes> raw_pk;
+    for (const column_definition& cdef : schema->partition_key_columns()) {
+        bytes raw_value = get_key_column_value(item, idx, cdef);
+        raw_pk.push_back(std::move(raw_value));
+    }
+    return partition_key::from_exploded(raw_pk);
+}
+
+clustering_key_prefix ck_from_json(rjson::value const& item, std::size_t idx, schema_ptr const& schema) {
+    if (schema->clustering_key_size() == 0) {
+        return clustering_key_prefix::make_empty();
+    }
+    std::vector<bytes> raw_ck;
+    for (const column_definition& cdef : schema->clustering_key_columns()) {
+        bytes raw_value = get_key_column_value(item, idx, cdef);
+        raw_ck.push_back(std::move(raw_value));
+    }
+
+    return clustering_key_prefix::from_exploded(raw_ck);
+}
+
+} // namespace
+
+namespace service {
+
+vector_store::vector_store() {
+    auto const* ip_env = std::getenv("VECTOR_STORE_IP");
+    auto const* port_env = std::getenv("VECTOR_STORE_PORT");
+
+    if (ip_env == nullptr || port_env == nullptr) {
+        vslogger.info("Disable Vector Store: Missing environment values");
+        return;
+    }
+
+    auto port = std::uint16_t{};
+    auto [ptr, ec] = std::from_chars(port_env, port_env + std::strlen(port_env), port);
+    if (*ptr != '\0' || ec != std::errc{}) {
+        vslogger.error("Disable Vector Store: Invalid port number: {}", port_env);
+        return;
+    }
+
+    _host = ip_env;
+    auto addr = net::inet_address{};
+    try {
+        addr = net::inet_address(_host);
+    } catch (const std::invalid_argument& e) {
+        vslogger.error("Disable Vector Store: Invalid ip address: {}", _host);
+        return;
+    }
+
+    _client = std::make_unique<client_t>(socket_address(addr, port));
+}
+
+vector_store::~vector_store() = default;
+
+void vector_store::set_service(socket_address const& addr) {
+    _client = std::make_unique<client_t>(addr);
+    _host = format("{}", addr);
+}
+
+[[nodiscard]] auto vector_store::ann(keyspace_name_t keyspace, index_name_t name, schema_ptr schema, embedding_t embedding, limit_t limit) const
+        -> future<std::optional<std::vector<primary_key_t>>> {
+    // TODO: fix error checking in the method
+
+    if (!_client) {
+        vslogger.error("Disabled Vector Store while calling ann");
+        co_return std::nullopt;
+    }
+
+    auto req = http::request::make("POST", _host, format("/api/v1/indexes/{}/{}/ann", keyspace, name));
+    req.write_body("json", [limit, embedding = std::move(embedding)](output_stream<char> out) -> future<> {
+        std::exception_ptr ex;
+        try {
+            co_await out.write(R"({"embedding":[)");
+            auto first = true;
+            for (auto value : embedding) {
+                if (!first) {
+                    co_await out.write(",");
+                } else {
+                    first = false;
+                }
+                co_await out.write(format("{}", value));
+            }
+            co_await out.write(format(R"(],"limit":{}}})", limit));
+            co_await out.flush();
+        } catch (...) {
+            ex = std::current_exception();
+        }
+        co_await out.close();
+        if (ex) {
+            co_await coroutine::return_exception_ptr(std::move(ex));
+        }
+    });
+
+    auto resp_status = make_lw_shared(http::reply::status_type::ok);
+    auto resp_content = make_lw_shared<std::vector<temporary_buffer<char>>>();
+    co_await _client->make_request(std::move(req), [resp_status, resp_content](http::reply const& reply, input_stream<char> body) -> future<> {
+        *resp_status = reply._status;
+        *resp_content = co_await util::read_entire_stream(body);
+    });
+
+    auto const resp = rjson::parse(std::move(*resp_content));
+    auto const& primary_keys = resp["primary_keys"];
+    auto const distances = resp["distances"].GetArray();
+    auto size = distances.Size();
+    auto keys = std::vector<primary_key_t>{};
+    for (auto idx = 0U; idx < size; ++idx) {
+        auto pk = pk_from_json(primary_keys, idx, schema);
+        auto ck = ck_from_json(primary_keys, idx, schema);
+        keys.push_back(primary_key_t{dht::decorate_key(*schema, std::move(pk)), ck});
+    }
+    co_return std::optional{keys};
+}
+
+} // namespace service
+

--- a/service/vector_store.hh
+++ b/service/vector_store.hh
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "cql3/statements/select_statement.hh"
+#include <seastar/core/shared_future.hh>
+
+namespace seastar::http::experimental {
+class client;
+}
+
+namespace service {
+
+/// An interface with the vector store service.
+class vector_store final {
+    using client_t = seastar::http::experimental::client;
+    using host_t = sstring;
+
+    std::unique_ptr<client_t> _client;
+    host_t _host; //< The host name for the HTTP protocol.
+
+public:
+    using keyspace_name_t = sstring;
+    using index_name_t = sstring;
+
+    using primary_key_t = cql3::statements::select_statement::primary_key;
+    using embedding_t = std::vector<float>;
+    using limit_t = std::size_t;
+
+    vector_store();
+    ~vector_store();
+
+    /// Change the service address.
+    void set_service(socket_address const& addr);
+
+    /// Request the vector store service for the primary keys of the nearest neighbors
+    [[nodiscard]] auto ann(keyspace_name_t keyspace, index_name_t name, schema_ptr schema, embedding_t embedding, limit_t limit) const
+            -> future<std::optional<std::vector<primary_key_t>>>;
+};
+
+} // namespace service
+

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -283,6 +283,8 @@ add_scylla_test(wrapping_interval_test
   KIND BOOST)
 add_scylla_test(address_map_test
   KIND SEASTAR)
+add_scylla_test(vector_store_test
+  KIND SEASTAR)
 
 add_scylla_test(combined_tests
   KIND SEASTAR
@@ -339,7 +341,6 @@ add_scylla_test(combined_tests
     sstable_directory_test.cc
     sstable_set_test.cc
     statement_restrictions_test.cc
-    storage_proxy_test.cc
     tablets_test.cc
     tracing_test.cc
     user_function_test.cc

--- a/test/boost/vector_store_test.cc
+++ b/test/boost/vector_store_test.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "service/vector_store.hh"
+#include "test/lib/cql_test_env.hh"
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <random>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/http/function_handlers.hh>
+#include <seastar/http/httpd.hh>
+#include <seastar/json/json_elements.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/short_streams.hh>
+
+
+namespace {
+
+using namespace seastar;
+
+using function_handler = httpd::function_handler;
+using http_server = httpd::http_server;
+using operation_type = httpd::operation_type;
+using reply = http::reply;
+using request = http::request;
+using routes = httpd::routes;
+using status_type = http::reply::status_type;
+using url = httpd::url;
+
+auto new_ephemeral_port() {
+    constexpr auto MIN_PORT = 49152;
+    constexpr auto MAX_PORT = 65535;
+
+    auto rd = std::random_device{};
+    return std::uniform_int_distribution<uint16_t>(MIN_PORT, MAX_PORT)(rd);
+}
+
+auto listen_on_ephemeral_port(std::unique_ptr<http_server> server) -> future<std::tuple<std::unique_ptr<http_server>, socket_address>> {
+    constexpr auto const* LOCALHOST = "127.0.0.1";
+    auto inaddr = net::inet_address(LOCALHOST);
+
+    while (true) {
+        auto addr = socket_address(inaddr, new_ephemeral_port());
+        try {
+            co_await server->listen(addr);
+            co_return std::make_tuple(std::move(server), addr);
+        } catch (const std::system_error& e) {
+            continue;
+        }
+    }
+}
+
+auto new_http_server(std::function<void(routes& r)> set_routes) -> future<std::tuple<std::unique_ptr<http_server>, socket_address>> {
+    auto server = std::make_unique<http_server>("test_vector_store");
+    set_routes(server->_routes);
+    server->set_content_streaming(true);
+    co_return co_await listen_on_ephemeral_port(std::move(server));
+}
+
+} // namespace
+
+SEASTAR_TEST_CASE(vector_store_test) {
+    return do_with_cql_env([](cql_test_env& env) -> future<> {
+        auto ann_replies = make_lw_shared<std::queue<std::tuple<sstring, sstring>>>();
+        auto [server, addr] = co_await new_http_server([ann_replies](routes& r) {
+            auto ann = [ann_replies](std::unique_ptr<request> req, std::unique_ptr<reply> rep) -> future<std::unique_ptr<reply>> {
+                BOOST_ASSERT(!ann_replies->empty());
+                auto [req_exp, rep_inp] = ann_replies->front();
+                auto const req_inp = co_await util::read_entire_stream_contiguous(*req->content_stream);
+                BOOST_CHECK_EQUAL(req_inp, req_exp);
+                ann_replies->pop();
+                rep->set_status(status_type::ok);
+                rep->write_body("json", rep_inp);
+                co_return rep;
+            };
+            r.add(operation_type::POST, url("/api/v1/indexes/ks/idx").remainder("ann"), new function_handler(ann, "json"));
+        });
+
+        co_await env.execute_cql(R"(
+                    create table ks.vs (
+                        pk1 tinyint, pk2 tinyint,
+                        ck1 tinyint, ck2 tinyint,
+                        embedding vector<float, 3>,
+                        primary key ((pk1, pk2), ck1, ck2))
+                )");
+        auto& db = env.local_db();
+        auto schema = db.find_schema("ks", "vs");
+
+        auto& vs = env.local_qp().vector_store();
+        vs.set_service(addr);
+
+        ann_replies->emplace(std::make_tuple(
+                R"({"embedding":[0.1,0.2,0.3],"limit":2})", R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"));
+        auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2);
+        BOOST_CHECK(keys);
+        BOOST_CHECK_EQUAL(keys->size(), 2);
+        BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(0).partition.key().explode()), "[05, 07]");
+        BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(0).clustering.explode()), "[09, 02]");
+        BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(1).partition.key().explode()), "[06, 08]");
+        BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(1).clustering.explode()), "[01, 03]");
+        co_await server->stop();
+    });
+}
+


### PR DESCRIPTION
The Vector Store service is a http server which provides vector search index and an ANN (Aproximate Nearest Neighbor) functionality. This patch adds a ScyllaDB service with an ann functionality interface. An ip:port address of the Vector Store service should be provided by VECTOR_STORE_IP and VECTOR_STORE_PORT environment while creating service or by running set_service method.

This patch adds also an automatic boost test, which runs mockup http server in background and then check the vector_store service with it.

References: VS-47